### PR TITLE
Ensure types returns Array with unique values

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,6 +229,9 @@ class Payload {
 
     // message button triggered by callback_id
     if (this.action) events.push('message_button', this.action.value)
+    
+    // ensure unique values
+    events = events.filter((v, i, a) => a.indexOf(v) === i); 
 
     return events
   }


### PR DESCRIPTION
In combination with [tinyspeck](https://www.npmjs.com/package/tinyspeck) the dupes (e.g. when `callback_id` is there, `type` will/can already be `interactive_message`) lead to dupe events emitted.